### PR TITLE
Implement project creation and export actions

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -26,6 +26,7 @@ import {
   WatermarkEffectConfig
 } from '../core/types/effect';
 import { PlaybackState } from '../core/types/audio';
+import { VideoEncoderService } from '../core/VideoEncoderService';
 import debug from 'debug';
 
 const log = debug('app:AppContext');
@@ -238,6 +239,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const managerInstance = useMemo(() => new EffectManager(), []);
   const drawingManager = useMemo(() => new DrawingManager(managerInstance), [managerInstance]);
   const analyzerService = useMemo(() => AudioAnalyzerService.getInstance(), []);
+  const encoderRef = useRef<VideoEncoderService | null>(null);
 
   const handleErrorCallback = useCallback((error: AppError) => {
     log('Handling error:', error);
@@ -458,9 +460,44 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   }, [managerInstance, dispatch, handleErrorCallback]);
 
   const createProject = useCallback(async (name: string, settings: VideoSettings) => {
-    console.log('[TODO] createProject called', name, settings);
-    // Implement project creation logic
-  }, []);
+    try {
+      const projectService = ProjectService.getInstance();
+      const project = await projectService.createProject(name, settings);
+
+      // Reset manager and clear existing effects
+      managerInstance.dispose();
+
+      dispatch({
+        type: 'SET_PROJECT',
+        payload: {
+          currentProject: project,
+          isLoading: false,
+          lastSaved: project.updatedAt
+        }
+      });
+
+      // Clear effects and audio state for the new project
+      dispatch({ type: 'SET_EFFECTS', payload: { effects: [], selectedEffect: null } });
+      dispatch({
+        type: 'SET_AUDIO',
+        payload: {
+          source: null,
+          currentTime: 0,
+          duration: 0,
+          isPlaying: false,
+          volume: 1,
+          loop: false,
+          analysis: undefined
+        }
+      });
+
+      dispatch({ type: 'SET_UI', payload: { selectedEffectId: null, isSettingsPanelOpen: false } });
+      transitionTo({ type: 'idle' });
+    } catch (error) {
+      console.error('Failed to create project:', error);
+      handleErrorCallback(error instanceof AppError ? error : new AppError(ErrorType.ProjectCreateFailed, 'プロジェクトの作成に失敗しました', error as Error));
+    }
+  }, [dispatch, managerInstance, transitionTo, handleErrorCallback]);
 
   const saveProject = useCallback(async () => {
     log('Attempting to save project...');
@@ -551,14 +588,72 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   }, [dispatch, managerInstance, handleErrorCallback]);
 
   const startExport = useCallback(async (settings: VideoSettings) => {
-    console.log('[TODO] startExport called', settings);
-    // Implement export logic
-  }, []);
+    if (!state.audioState.source?.buffer) {
+      handleErrorCallback(new AppError(ErrorType.INVALID_STATE, 'Valid audio source is required for export.'));
+      return;
+    }
+
+    try {
+      transitionTo({ type: 'exporting', settings });
+
+      const buffer = state.audioState.source.buffer;
+      encoderRef.current = new VideoEncoderService({
+        width: settings.width,
+        height: settings.height,
+        frameRate: settings.frameRate,
+        videoBitrate: settings.videoBitrate,
+        audioBitrate: settings.audioBitrate,
+        sampleRate: buffer.sampleRate,
+        channels: buffer.numberOfChannels
+      });
+
+      const totalFrames = Math.ceil(buffer.duration * settings.frameRate);
+      const encoder = encoderRef.current;
+      await encoder.initialize(undefined, totalFrames);
+
+      const canvas = drawingManager.createExportCanvas({
+        width: settings.width,
+        height: settings.height
+      });
+
+      for (let frameIndex = 0; frameIndex < totalFrames; frameIndex++) {
+        const currentTime = frameIndex / settings.frameRate;
+        managerInstance.updateAll(currentTime);
+        drawingManager.renderExportFrame(canvas, currentTime);
+        await encoder.encodeVideoFrame(canvas, frameIndex);
+        await encoder.encodeAudioBuffer(buffer, frameIndex);
+      }
+
+      const mp4Binary = await encoder.finalize();
+      const blob = new Blob([mp4Binary], { type: 'video/mp4' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${state.projectState.currentProject?.name || 'output'}.mp4`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      transitionTo({ type: 'ready' });
+    } catch (error) {
+      console.error('Export failed:', error);
+      handleErrorCallback(error instanceof AppError ? error : new AppError(ErrorType.EXPORT_ENCODE_FAILED, 'エクスポートに失敗しました', error as Error));
+      transitionTo({ type: 'ready' });
+    } finally {
+      encoderRef.current?.dispose();
+      encoderRef.current = null;
+    }
+  }, [state.audioState.source, drawingManager, managerInstance, transitionTo, handleErrorCallback]);
 
   const cancelExport = useCallback(() => {
-    console.log('[TODO] cancelExport called');
-    // Implement export cancellation logic
-  }, []);
+    if (encoderRef.current) {
+      encoderRef.current.cancel();
+      encoderRef.current.dispose();
+      encoderRef.current = null;
+    }
+    transitionTo({ type: 'ready' });
+  }, [transitionTo]);
 
   const contextValue = useMemo<AppContextType>(() => ({
     ...state,


### PR DESCRIPTION
## Summary
- flesh out `createProject`, `startExport` and `cancelExport`
- add VideoEncoderService reference and export logic

## Testing
- `npm test` *(no tests found)*
- `npm run lint` *(fails: Invalid option '--ext')*