### PR TITLE
Replace `any` with specific types

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -247,7 +247,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     });
   }, [dispatch]);
 
-  const addEffect = useCallback(async (effect: EffectBase<any>) => {
+  const addEffect = useCallback(async (effect: EffectBase<EffectConfig>) => {
     try {
       await managerInstance.addEffect(effect);
       // Get the updated list from the manager to ensure consistency
@@ -510,9 +510,9 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
       // エフェクトの復元
       managerInstance.dispose();
-      loadedProjectData.effects.forEach((config: any) => {
+      loadedProjectData.effects.forEach((config: EffectConfig) => {
         try {
-          let effectInstance: EffectBase<any>;
+          let effectInstance: EffectBase<EffectConfig>;
           if (config.type === 'background') {
               effectInstance = new BackgroundEffect(config as BackgroundEffectConfig);
           } else if (config.type === 'text') {

--- a/src/core/Renderer.ts
+++ b/src/core/Renderer.ts
@@ -12,8 +12,8 @@ const PREVIEW_MAX_WIDTH = 1280;
 const PREVIEW_MAX_HEIGHT = 720;
 
 export class Renderer {
-  private canvas: HTMLCanvasElement;
-  private offscreenCanvas: HTMLCanvasElement;
+  private canvas: HTMLCanvasElement | null;
+  private offscreenCanvas: HTMLCanvasElement | null;
   private ctx: CanvasRenderingContext2D | null = null;
   private offscreenCtx: CanvasRenderingContext2D | null = null;
   private scale: number = 1;
@@ -86,10 +86,10 @@ export class Renderer {
       previewWidth = Math.round(PREVIEW_MAX_HEIGHT * aspectRatio);
     }
 
-    this.canvas.width = previewWidth;
-    this.canvas.height = previewHeight;
-    this.offscreenCanvas.width = previewWidth;
-    this.offscreenCanvas.height = previewHeight;
+    this.canvas!.width = previewWidth;
+    this.canvas!.height = previewHeight;
+    this.offscreenCanvas!.width = previewWidth;
+    this.offscreenCanvas!.height = previewHeight;
 
     // スケールを計算
     this.scale = width / previewWidth;
@@ -108,8 +108,8 @@ export class Renderer {
     this.scale = scale;
     
     // スケールに応じてオフスクリーンキャンバスのサイズを調整
-    this.offscreenCanvas.width = Math.round(this.canvas.width * scale);
-    this.offscreenCanvas.height = Math.round(this.canvas.height * scale);
+    this.offscreenCanvas!.width = Math.round(this.canvas!.width * scale);
+    this.offscreenCanvas!.height = Math.round(this.canvas!.height * scale);
     
     // 描画設定を再適用
     if (this.offscreenCtx) {
@@ -138,21 +138,21 @@ export class Renderer {
     if (!this.ctx || !this.offscreenCtx) return;
 
     // メインキャンバスをクリア
-    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.clearRect(0, 0, this.canvas!.width, this.canvas!.height);
 
     // スケールを考慮して描画
     if (this.scale !== 1) {
       this.ctx.save();
       this.ctx.scale(1 / this.scale, 1 / this.scale);
       this.ctx.drawImage(
-        this.offscreenCanvas,
+        this.offscreenCanvas!,
         0, 0,
-        this.offscreenCanvas.width,
-        this.offscreenCanvas.height
+        this.offscreenCanvas!.width,
+        this.offscreenCanvas!.height
       );
       this.ctx.restore();
     } else {
-      this.ctx.drawImage(this.offscreenCanvas, 0, 0);
+      this.ctx.drawImage(this.offscreenCanvas!, 0, 0);
     }
   }
 
@@ -162,9 +162,10 @@ export class Renderer {
   clear(): void {
     if (this.offscreenCtx) {
       this.offscreenCtx.clearRect(
-        0, 0,
-        this.offscreenCanvas.width,
-        this.offscreenCanvas.height
+        0,
+        0,
+        this.offscreenCanvas!.width,
+        this.offscreenCanvas!.height
       );
     }
   }
@@ -174,8 +175,8 @@ export class Renderer {
    */
   getOriginalSize(): { width: number; height: number } {
     return this.originalSize ?? {
-      width: Math.round(this.canvas.width * this.scale),
-      height: Math.round(this.canvas.height * this.scale)
+      width: Math.round(this.canvas!.width * this.scale),
+      height: Math.round(this.canvas!.height * this.scale)
     };
   }
 
@@ -184,8 +185,8 @@ export class Renderer {
    */
   getCurrentSize(): { width: number; height: number } {
     return {
-      width: this.canvas.width,
-      height: this.canvas.height
+      width: this.canvas!.width,
+      height: this.canvas!.height
     };
   }
 
@@ -205,8 +206,14 @@ export class Renderer {
 
   /**
    * キャンバス要素を取得
-   */
+  */
   getCanvas(): HTMLCanvasElement {
+    if (!this.canvas) {
+      throw new AppError(
+        ErrorType.RENDERER_ERROR,
+        'Canvas is not available'
+      );
+    }
     return this.canvas;
   }
 
@@ -222,7 +229,7 @@ export class Renderer {
     this.offscreenCtx = null;
     
     // キャンバス要素の参照を解放
-    this.canvas = null as any;
-    this.offscreenCanvas = null as any;
+    this.canvas = null;
+    this.offscreenCanvas = null;
   }
 }

--- a/src/core/VideoEncoderService.ts
+++ b/src/core/VideoEncoderService.ts
@@ -50,7 +50,7 @@ export class VideoEncoderService implements Disposable {
   // Promise for finalize result
   private finalizePromise: Promise<Uint8Array> | null = null;
   private resolveFinalize: ((value: Uint8Array | PromiseLike<Uint8Array>) => void) | null = null;
-  private rejectFinalize: ((reason?: any) => void) | null = null;
+  private rejectFinalize: ((reason?: AppError) => void) | null = null;
 
   // Progress callback
   private onProgress: ProgressCallback | null = null;

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -58,6 +58,8 @@ export type {
   Renderer
 } from './core';
 
+export type { RenderContext } from './render';
+
 // 状態管理関連
 export type { AppPhase } from './state';
 export type {

--- a/src/core/types/render.ts
+++ b/src/core/types/render.ts
@@ -1,0 +1,1 @@
+export type RenderContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;

--- a/src/core/workers/encodeWorker.ts
+++ b/src/core/workers/encodeWorker.ts
@@ -199,9 +199,10 @@ self.onmessage = async (event: MessageEvent<WorkerIncomingMessage>) => {
       isInitialized = false; // 完了したらリセット
     }
 
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown worker error';
     console.error('[Worker] Error:', error);
-    self.postMessage({ type: 'error', message: error.message || 'Unknown worker error' });
+    self.postMessage({ type: 'error', message });
     isInitialized = false; // エラー時もリセット
     videoEncoder?.close();
     audioEncoder?.close();

--- a/src/features/text/TextEffect.ts
+++ b/src/features/text/TextEffect.ts
@@ -5,6 +5,11 @@ import { Color } from '../../core/types/base';
 import { convertPosition } from '../../utils/coordinates';
 import { AudioSource } from '../../core/audio/AudioSource';
 import { RenderContext } from '../../core/types/render';
+
+interface CanvasTextRenderingContext2D extends CanvasRenderingContext2D {
+  fontKerning?: string;
+  textRendering?: string;
+}
 import { BoundingBox } from '../../core/types/base';
 
 /**
@@ -66,10 +71,10 @@ export class TextEffect extends EffectBase<TextEffectConfig> {
     
     // テキストレンダリングの最適化（高品質設定）
     if ('fontKerning' in ctx) {
-      (ctx as any).fontKerning = 'normal';
+      (ctx as CanvasTextRenderingContext2D).fontKerning = 'normal';
     }
     if ('textRendering' in ctx) {
-      (ctx as any).textRendering = 'optimizeLegibility';
+      (ctx as CanvasTextRenderingContext2D).textRendering = 'optimizeLegibility';
     }
     
     // フォント設定の最適化（より正確なピクセル合わせ）

--- a/src/ui/PreviewCanvas.tsx
+++ b/src/ui/PreviewCanvas.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, memo, useMemo, useCallback, useState } from 'react';
 import debug from 'debug';
-import { EffectManager } from '../core/types/core';
+import { EffectManager, EffectBase, EffectConfig } from '../core/types/core';
 import { AppError, ErrorType } from '../core/types/error';
 import { withAppError } from '../core/types/app';
 import { Renderer } from '../core/Renderer';
@@ -52,25 +52,25 @@ const lastLogTimes = {
 
 // ログ出力のユーティリティオブジェクト
 const logger = {
-  error: (message: string, data?: any) => {
+  error: (message: string, data?: unknown) => {
     if (CURRENT_LOG_LEVEL >= LOG_LEVEL.ERROR) {
       console.error(`[PreviewCanvas:ERROR] ${message}`, data);
     }
   },
   
-  warn: (message: string, data?: any) => {
+  warn: (message: string, data?: unknown) => {
     if (CURRENT_LOG_LEVEL >= LOG_LEVEL.WARN) {
       console.warn(`[PreviewCanvas:WARN] ${message}`, data);
     }
   },
   
-  info: (message: string, data?: any) => {
+  info: (message: string, data?: unknown) => {
     if (CURRENT_LOG_LEVEL >= LOG_LEVEL.INFO) {
       console.info(`[PreviewCanvas:INFO] ${message}`, data);
     }
   },
   
-  debug: (message: string, data?: any) => {
+  debug: (message: string, data?: unknown) => {
     if (CURRENT_LOG_LEVEL >= LOG_LEVEL.DEBUG && DEBUG_ENABLED) {
       const now = Date.now();
       // 500ms以内に同じカテゴリのログは出力しない（頻発するログの間引き）
@@ -81,7 +81,7 @@ const logger = {
     }
   },
   
-  verbose: (message: string, data?: any, throttleInterval = 500) => {
+  verbose: (message: string, data?: unknown, throttleInterval = 500) => {
     if (CURRENT_LOG_LEVEL >= LOG_LEVEL.VERBOSE && DEBUG_ENABLED) {
       const now = Date.now();
       // throttleIntervalミリ秒以内に同じカテゴリのログは出力しない
@@ -94,9 +94,9 @@ const logger = {
 };
 
 // 従来のdebugLog関数（後方互換性用）
-function debugLog(...args: any[]): void {
+function debugLog(message: string, ...args: unknown[]): void {
   if (DEBUG_ENABLED) {
-    logger.debug(args[0], args.slice(1));
+    logger.debug(message, args);
   }
 }
 
@@ -110,7 +110,7 @@ interface PreviewCanvasProps {
 }
 
 // テキストエフェクト型ガード
-function isTextEffect(config: any): config is TextEffectConfig {
+function isTextEffect(config: EffectConfig): config is TextEffectConfig {
   return config && config.type === 'text';
 }
 
@@ -314,7 +314,7 @@ export const PreviewCanvas: React.FC<PreviewCanvasProps> = memo(({
   }, []);
 
   // エフェクトのヒットテスト（マウス位置とエフェクトの衝突判定）
-  const hitTestEffects = useCallback((position: Position, effectsList: any[]): any | null => {
+  const hitTestEffects = useCallback((position: Position, effectsList: EffectBase<EffectConfig>[]): EffectBase<EffectConfig> | null => {
     // 後ろから前の順に検査（表示順の逆順）
     for (let i = effectsList.length - 1; i >= 0; i--) {
       const effect = effectsList[i];


### PR DESCRIPTION
## Summary
- remove all `any` usages across the codebase
- define `RenderContext` type
- tighten effect types in context and preview logic
- improve renderer cleanup
- refine logging and context types for text effect

## Testing
- `npm test` *(no tests found)*